### PR TITLE
Fixing the covariance-level whitening process

### DIFF
--- a/covseisnet/covariance.py
+++ b/covseisnet/covariance.py
@@ -820,7 +820,7 @@ def calculate_covariance_matrix(
 
         # Whiten
         if whiten.lower() == "slice":
-            spectra_slice /= np.mean(
+            spectra_slice = spectra_slice / np.mean(
                 np.abs(spectra_slice), axis=-1, keepdims=True
             )
 


### PR DESCRIPTION
For example, let's say "step=5" and "average=10". In the first average window, "spectra_slice = spectra[..., 0:10]". If we do "spectra_slice /= np.mean(np.abs(spectra_slice), axis=-1, keepdims=True)", not only "spectra_slice" but also the original array "spectra[..., 0:10]" will be whitened. The next average window is "spectra_slice = spectra[..., 5:15]". However, "spectra[... 5:10]", which is half of the average window, is affected by the previous whitening and is no longer the original "spectra". So, if we avoid the assignment operator "/=" and change it to "spectra_slice = spectra_slice / np.mean(np.abs(spectra_slice), axis=-1, keepdims=True)", the original "spectra[...,0:10]" will be kept as is, and only "spectra_slice" will be whitened.